### PR TITLE
Added new test for creation of proxies of instances with properties that are assigned a value from the constructor.

### DIFF
--- a/TrackerDog.Test/ProxyCreationTest.cs
+++ b/TrackerDog.Test/ProxyCreationTest.cs
@@ -25,6 +25,16 @@ namespace TrackerDog.Test
             public virtual string Text { get; set; }
         }
 
+        public class D
+        {
+            public virtual string Text { get; set; }
+
+            public D()
+            {
+                Text = "some text";
+            }
+        }
+
         private static ITrackableObjectFactory TrackableObjectFactory { get; set; }
 
         private static IObjectChangeTrackingConfiguration Configuration { get; set; }
@@ -35,7 +45,8 @@ namespace TrackerDog.Test
             Configuration = ObjectChangeTracking.CreateConfiguration()
                 .TrackThisType<A>()
                 .TrackThisType<B>()
-                .TrackThisType<C>();
+                .TrackThisType<C>()
+                .TrackThisType<D>();
 
             TrackableObjectFactory = Configuration.CreateTrackableObjectFactory();
         }
@@ -70,6 +81,17 @@ namespace TrackerDog.Test
             Assert.IsTrue(b.IsTrackable());
 
             b.Text = "hello world";
+        }
+
+        [TestMethod]
+        public void CanCreateProxyWhenPropertyInitializedFromConstructor()
+        {
+            D d1 = new D();
+            D trackedD1 = TrackableObjectFactory.CreateFrom(d1);
+
+            Assert.IsTrue(d1.IsTrackable());
+
+
         }
     }
 }

--- a/TrackerDog.sln
+++ b/TrackerDog.sln
@@ -1,13 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrackerDog", "TrackerDog\TrackerDog.csproj", "{2600FECF-EF1A-4156-9108-D6C713F704F9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrackerDog.Test", "TrackerDog.Test\TrackerDog.Test.csproj", "{EB8B12CC-777D-4205-9B00-46C96E5080B7}"
-EndProject
-Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "TrackerDog.Documentation", "TrackerDog.Documentation\TrackerDog.Documentation.shfbproj", "{744376C5-CDDE-4502-8092-A284E2A7C774}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "git", "git", "{E0E234F7-08B1-4766-85E9-AF57953F34F8}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,16 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "git", "git", "{E0E234F7-08B
 		.gitignore = .gitignore
 	EndProjectSection
 EndProject
-Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "TrackerDog.NuGet", "TrackerDog.NuGet\TrackerDog.NuGet.nuproj", "{48F79414-05BF-437C-861D-CBC620EBD9B5}"
-	ProjectSection(ProjectDependencies) = postProject
-		{2600FECF-EF1A-4156-9108-D6C713F704F9} = {2600FECF-EF1A-4156-9108-D6C713F704F9}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrackerDog.Signed", "TrackerDog.Signed\TrackerDog.Signed.csproj", "{49A0992E-1629-4AB7-82E9-695F1FE093FF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrackerDog.Test.Signed", "TrackerDog.Test.Signed\TrackerDog.Test.Signed.csproj", "{8B2D822D-FFE5-4878-8003-D609B4B2A277}"
-EndProject
-Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "TrackerDog.NuGet.Signed", "TrackerDog.NuGet.Signed\TrackerDog.NuGet.Signed.nuproj", "{0C0AD994-7E6D-48BA-AF5E-36E60DFD6FF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,12 +31,6 @@ Global
 		{EB8B12CC-777D-4205-9B00-46C96E5080B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB8B12CC-777D-4205-9B00-46C96E5080B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB8B12CC-777D-4205-9B00-46C96E5080B7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{744376C5-CDDE-4502-8092-A284E2A7C774}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{744376C5-CDDE-4502-8092-A284E2A7C774}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{744376C5-CDDE-4502-8092-A284E2A7C774}.Release|Any CPU.Build.0 = Release|Any CPU
-		{48F79414-05BF-437C-861D-CBC620EBD9B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{48F79414-05BF-437C-861D-CBC620EBD9B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{48F79414-05BF-437C-861D-CBC620EBD9B5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{49A0992E-1629-4AB7-82E9-695F1FE093FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{49A0992E-1629-4AB7-82E9-695F1FE093FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49A0992E-1629-4AB7-82E9-695F1FE093FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,10 +39,6 @@ Global
 		{8B2D822D-FFE5-4878-8003-D609B4B2A277}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B2D822D-FFE5-4878-8003-D609B4B2A277}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B2D822D-FFE5-4878-8003-D609B4B2A277}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0C0AD994-7E6D-48BA-AF5E-36E60DFD6FF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C0AD994-7E6D-48BA-AF5E-36E60DFD6FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C0AD994-7E6D-48BA-AF5E-36E60DFD6FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0C0AD994-7E6D-48BA-AF5E-36E60DFD6FF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
When I try to create a proxy from a class that assigns a value to a property from the constructor a NullReferenceException is thrown.

I know that calling virtual member functions from the constructor can cause problems, but the property is only virtual because it is necessary for proxy creation.

I have added a new test to ProxyCreationTest.cs that reproduces this issue.
